### PR TITLE
Added missing hyphen in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ dcliah --name mesh#3230 --moment weekly
 Let's view our historic Crucible stats across all of our characters for all time:
 
 ```
-$ dcliah --name mesh#3230 --mode all_pvp --moment all_time -class all
+$ dcliah --name mesh#3230 --mode all_pvp --moment all_time --class all
 ```
 
 ### Putting it all together


### PR DESCRIPTION
Added missing hyphen to `--class` option in the historic crucible stats example.

[branch: readme-flag]