### PR TITLE
Add User-Agent Header

### DIFF
--- a/src/dcli/src/apiclient.rs
+++ b/src/dcli/src/apiclient.rs
@@ -56,6 +56,8 @@ impl ApiClient {
 
         headers.insert("X-API-Key", HeaderValue::from_str(key).unwrap());
 
+        headers.insert("User-Agent", HeaderValue::from_static("dcli"));
+
         let client = Client::builder()
             .default_headers(headers)
             .timeout(std::time::Duration::from_secs(API_TIMEOUT))


### PR DESCRIPTION
The bungie api now requires a User-Agent header for most requests.